### PR TITLE
Add module entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.3",
   "description": "NodeJS string dedenting module – make your template strings look nice!",
   "main": "dist/index.js",
+  "module": "src/index.js",
   "scripts": {
     "cover": "babel-node ./node_modules/.bin/isparta cover ./node_modules/mocha/bin/_mocha test/",
     "codecov": "npm run cover && codecov",


### PR DESCRIPTION
Hello!

This adds a module entry point to package.json, which will allow bundlers that support the ES Module spec to bundle the module version without potentially including some of the CommonJS interop that's added to dist/index.js. It'll also let people who use things like unpkg.com to include the dentist module from a browser directly, without needing a bundler.

Because of webpack behavior, this requires a major version bump ([explanation here](https://gist.github.com/tmcw/b90666454d424ebdaa3904dc1d9c7620)).